### PR TITLE
feat: `no_std` compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
  "rand",
  "sha2",
  "substrate-bn",
- "thiserror",
+ "thiserror-no-std",
 ]
 
 [[package]]
@@ -464,23 +464,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.63"
+name = "thiserror-impl-no-std"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "thiserror-no-std"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
+dependencies = [
+ "thiserror-impl-no-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,9 +386,6 @@ dependencies = [
 name = "snark-bn254-verifier"
 version = "1.0.2"
 dependencies = [
- "lazy_static",
- "num-bigint",
- "num-traits",
  "rand",
  "sha2",
  "substrate-bn",

--- a/examples/script/Cargo.toml
+++ b/examples/script/Cargo.toml
@@ -8,7 +8,6 @@ clap = { version = "4.0", features = ["derive", "env"] }
 hex = "0.4.3"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
-sp1-prover = "2.0.0"
 sp1-sdk = "2.0.0"
 strum = "0.25"
 strum_macros = "0.25"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -13,9 +13,6 @@ version = "1.0.2"
 
 [dependencies]
 bn = { git = "https://github.com/sp1-patches/bn", branch = "patch-v0.7.0", package = "substrate-bn" }
-lazy_static = "1.5.0"
-num-bigint = "0.4.6"
-num-traits = "0.2.19"
 rand = "0.8.5"
 sha2 = "0.10.8"
 thiserror-no-std = "2.0.2"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2021"
 version = "1.0.2"
 
 [dependencies]
+thiserror-no-std = "2.0.2"
 bn = { git = "https://github.com/sp1-patches/bn", branch = "patch-v0.7.0", package = "substrate-bn" }
 lazy_static = "1.5.0"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 rand = "0.8.5"
 sha2 = "0.10.8"
-thiserror = "1.0.63"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2021"
 version = "1.0.2"
 
 [dependencies]
-thiserror-no-std = "2.0.2"
 bn = { git = "https://github.com/sp1-patches/bn", branch = "patch-v0.7.0", package = "substrate-bn" }
 lazy_static = "1.5.0"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 rand = "0.8.5"
 sha2 = "0.10.8"
+thiserror-no-std = "2.0.2"

--- a/verifier/src/converter.rs
+++ b/verifier/src/converter.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 use bn::{AffineG1, AffineG2, Fq, Fq2};
 

--- a/verifier/src/error.rs
+++ b/verifier/src/error.rs
@@ -1,5 +1,5 @@
 use bn::{CurveError, FieldError, GroupError};
-use thiserror::Error;
+use thiserror_no_std::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/verifier/src/groth16/converter.rs
+++ b/verifier/src/groth16/converter.rs
@@ -1,3 +1,4 @@
+use alloc::{vec, vec::Vec};
 use bn::AffineG1;
 
 use crate::{

--- a/verifier/src/groth16/error.rs
+++ b/verifier/src/groth16/error.rs
@@ -1,4 +1,4 @@
-use thiserror::Error;
+use thiserror_no_std::Error;
 
 #[derive(Debug, Error)]
 pub enum Groth16Error {

--- a/verifier/src/groth16/verify.rs
+++ b/verifier/src/groth16/verify.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use bn::{pairing, pairing_batch, AffineG1, AffineG2, Fr, Gt, G1, G2};
 
 use super::error::Groth16Error;

--- a/verifier/src/hash_to_field.rs
+++ b/verifier/src/hash_to_field.rs
@@ -1,3 +1,4 @@
+use alloc::vec::{self, Vec};
 use core::hash::Hasher;
 use sha2::Digest;
 

--- a/verifier/src/hash_to_field.rs
+++ b/verifier/src/hash_to_field.rs
@@ -1,4 +1,5 @@
-use alloc::vec::{self, Vec};
+use alloc::vec;
+use alloc::vec::Vec;
 use core::hash::Hasher;
 use sha2::Digest;
 

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -3,6 +3,8 @@
 #![deny(missing_docs)]
 
 //! This crate provides verifiers for Groth16 and Plonk zero-knowledge proofs.
+#![no_std]
+extern crate alloc;
 
 use bn::Fr;
 use groth16::{

--- a/verifier/src/plonk/converter.rs
+++ b/verifier/src/plonk/converter.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     error::Error,
 };
+use alloc::vec::Vec;
 use bn::{AffineG1, Fr, G2};
 
 use super::{

--- a/verifier/src/plonk/error.rs
+++ b/verifier/src/plonk/error.rs
@@ -1,4 +1,4 @@
-use thiserror::Error;
+use thiserror_no_std::Error;
 
 #[derive(Error, Debug)]
 pub enum PlonkError {

--- a/verifier/src/plonk/kzg.rs
+++ b/verifier/src/plonk/kzg.rs
@@ -1,4 +1,4 @@
-use alloc::{string::ToString, vec::Vec};
+use alloc::{string::ToString, vec, vec::Vec};
 use bn::{pairing_batch, AffineG1, Fr, G1, G2};
 use rand::rngs::OsRng;
 

--- a/verifier/src/plonk/kzg.rs
+++ b/verifier/src/plonk/kzg.rs
@@ -1,3 +1,4 @@
+use alloc::{string::ToString, vec::Vec};
 use bn::{pairing_batch, AffineG1, Fr, G1, G2};
 use rand::rngs::OsRng;
 

--- a/verifier/src/plonk/proof.rs
+++ b/verifier/src/plonk/proof.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use super::kzg::{BatchOpeningProof, Digest, OpeningProof};
 
 #[derive(Debug)]

--- a/verifier/src/plonk/verify.rs
+++ b/verifier/src/plonk/verify.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use bn::{arith::U256, AffineG1, Fr};
 use core::hash::Hasher;
 

--- a/verifier/src/plonk/verify.rs
+++ b/verifier/src/plonk/verify.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{string::ToString, vec, vec::Vec};
 use bn::{arith::U256, AffineG1, Fr};
 use core::hash::Hasher;
 

--- a/verifier/src/transcript.rs
+++ b/verifier/src/transcript.rs
@@ -1,5 +1,5 @@
+use alloc::vec::Vec;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
 
 use crate::error::Error;
 

--- a/verifier/src/transcript.rs
+++ b/verifier/src/transcript.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec::Vec};
+use alloc::{collections::btree_map::BTreeMap, string::String, vec::Vec};
 use sha2::{Digest, Sha256};
 
 use crate::error::Error;
@@ -15,7 +15,7 @@ pub(crate) struct Challenge {
 pub(crate) struct Transcript {
     pub(crate) h: Sha256,
 
-    pub(crate) challenges: HashMap<String, Challenge>,
+    pub(crate) challenges: BTreeMap<String, Challenge>,
     previous_challenge: Option<Challenge>,
 }
 
@@ -24,7 +24,7 @@ impl Transcript {
         let h = Sha256::new();
 
         if let Some(challenges_id) = challenges_id {
-            let mut challenges = HashMap::new();
+            let mut challenges = BTreeMap::new();
             for (position, id) in challenges_id.iter().enumerate() {
                 challenges.insert(
                     id.clone(),
@@ -45,7 +45,7 @@ impl Transcript {
         } else {
             Ok(Transcript {
                 h,
-                challenges: HashMap::new(),
+                challenges: BTreeMap::new(),
                 previous_challenge: None,
             })
         }

--- a/verifier/src/transcript.rs
+++ b/verifier/src/transcript.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use sha2::{Digest, Sha256};
 
 use crate::error::Error;


### PR DESCRIPTION
For `no_std` compatibility, the usage of `HashMap` and `rand` both needs to be removed.