### PR TITLE
feat: Use `getrandom` feature on `rand` to compile to `no-std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "substrate-bn"
 version = "0.7.0"
-source = "git+https://github.com/sp1-patches/bn?branch=ratan/fix-patch-0.7.0#5a84d298254519da61900d1506308c341aea8456"
+source = "git+https://github.com/sp1-patches/bn?branch=patch-v0.7.0#3c53d2561492f26b9428c1d37d134031d0156152"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,15 +256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,18 +288,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
  "rand_core",
 ]
 
@@ -425,7 +404,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "substrate-bn"
 version = "0.7.0"
-source = "git+https://github.com/sp1-patches/bn?branch=patch-v0.7.0#2f5d4394b28550e47b16b061372832cba6d2dcf6"
+source = "git+https://github.com/sp1-patches/bn?branch=ratan/fix-patch-0.7.0#5a84d298254519da61900d1506308c341aea8456"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -528,25 +507,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 version = "1.0.2"
 
 [dependencies]
-bn = { git = "https://github.com/sp1-patches/bn", branch = "patch-v0.7.0", package = "substrate-bn" }
-rand = "0.8.5"
+bn = { git = "https://github.com/sp1-patches/bn", branch = "ratan/fix-patch-0.7.0", package = "substrate-bn" }
 sha2 = "0.10.8"
 thiserror-no-std = "2.0.2"
+rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 version = "1.0.2"
 
 [dependencies]
-bn = { git = "https://github.com/sp1-patches/bn", branch = "ratan/fix-patch-0.7.0", package = "substrate-bn" }
+bn = { git = "https://github.com/sp1-patches/bn", branch = "patch-v0.7.0", package = "substrate-bn" }
 sha2 = "0.10.8"
 thiserror-no-std = "2.0.2"
 rand = { version = "0.8.5", default-features = false, features = ["getrandom"] }

--- a/verifier/src/plonk/kzg.rs
+++ b/verifier/src/plonk/kzg.rs
@@ -146,7 +146,6 @@ pub(crate) fn batch_verify_multi_points(
     if nb_digests == 1 {
         todo!();
     }
-
     let mut rng = OsRng;
     let mut random_numbers = Vec::with_capacity(nb_digests);
     random_numbers.push(Fr::one());


### PR DESCRIPTION
The default `rand` feature does not work in `no-std`. Add `getrandom` feature on `rand` for this to compile.

Tested in https://github.com/ratankaliani/avail/pull/2